### PR TITLE
Items always being randomized

### DIFF
--- a/randomizer_gui.py
+++ b/randomizer_gui.py
@@ -118,7 +118,7 @@ class RandomizerUI(Frame):
         self.args.no_map = not 'A' in flags
         self.args.no_chests = not 'C' in flags
         self.args.speed_hacks = 'H' in flags
-        self.args.no_search_items = not 'I' in flags
+        self.args.no_searchitems = not 'I' in flags
         self.args.shuffle_music = 'K' in flags
         self.args.disable_music = 'Q' in flags
         self.args.no_towns = not 'T' in flags


### PR DESCRIPTION
When I create a ROM with no randomization, treasures are always shuffled because the arguments do not match between the GUI and the main randomizer program.  I propose changing the GUI side.