### PR TITLE
copy check + small wait

### DIFF
--- a/ui/main-window.cpp
+++ b/ui/main-window.cpp
@@ -299,6 +299,10 @@ void MainWindow::handleButton()
     if (crc) {
         sprintf(checksum, "Checksum: %016" PRIx64, crc);
         QGuiApplication::clipboard()->setText(checksum);
+        if(QGuiApplication::clipboard()->text() != checksum){    
+            QTest::qSleep(50);
+            QGuiApplication::clipboard()->setText(checksum);
+            }
         this->statusBar()->showMessage(
                 QString("%1 (copied to clipboard)").arg(checksum));
         QMessageBox::information(this, "Success!",


### PR DESCRIPTION
Attempting to address copy failure behavior. [Source issue](https://github.com/mcgrew/dwrandomizer/issues/108 ) need to isolate into an additional private function and make more robust without creating potential for infinite loop (constant failure of copy for some reason- solution: maybe a try up to N times and fail otherwise). Willing to code other solutions re:issue if this approach is not desired; some resources mention this failure may be patched out in QT versions, if QT is out of date; however, that may be more involved than a simple check/retry. 