### PR TITLE
Permanent torch

### DIFF
--- a/common/dwr.c
+++ b/common/dwr.c
@@ -1455,12 +1455,6 @@ static void permanent_torch(dw_rom *rom)
             0xea,               /* NOP       ;  (Y is set to 0)               */
             0x84,  0xda         /* STY $DA   ;  set radiant timer             */
     );
-    vpatch(rom, 0x0ca68,    4,
-            0xea,               /* NOP       ; Skip decrementing              */
-            0xea,               /* NOP       ;  radiant timer                 */
-            0xea,               /* NOP       ;  when walking                  */
-            0xea                /* NOP                                        */
-    );
     vpatch(rom, 0x0dd1e,    6,
             0xea,               /* NOP       ; Skip map type check            */
             0xea,               /* NOP       ;  when using torch              */

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -984,14 +984,13 @@ static void randomize_spells(dw_rom *rom)
         }
     }
 
-    
-
     for (i=0; i < 30; i++) {
         stats = &rom->stats[i];
         stats->spells = 0;
         for (j=HEAL; j <= HURTMORE; j++) {
-            if ((j == REPEL && PERMANENT_REPEL(rom)) || 
-                (j == HURTMORE && NO_HURTMORE(rom)))
+            if ((j == REPEL && PERMANENT_REPEL(rom)) ||
+                (j == HURTMORE && NO_HURTMORE(rom)) ||
+                (j == RADIANT && PERMANENT_TORCH(rom))
                 continue;
             /* spell masks are in big endian format */
             if (rom->new_spells[j].level <= i+1) {

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -990,7 +990,7 @@ static void randomize_spells(dw_rom *rom)
         for (j=HEAL; j <= HURTMORE; j++) {
             if ((j == REPEL && PERMANENT_REPEL(rom)) ||
                 (j == HURTMORE && NO_HURTMORE(rom)) ||
-                (j == RADIANT && PERMANENT_TORCH(rom))
+                (j == RADIANT && PERMANENT_TORCH(rom)))
                 continue;
             /* spell masks are in big endian format */
             if (rom->new_spells[j].level <= i+1) {
@@ -1450,10 +1450,10 @@ static void permanent_torch(dw_rom *rom)
     printf("Illuminating all the caves...\n");
 
     vpatch(rom, 0x02f18,    7,
-            0xa5,  0x03,        /* LDA #$03  ; When loading map               */
+            0xa9,  0x03,        /* LDA #$03  ; When loading map               */
             0x85,  0xd0,        /* STA $D0   ;  set size of torch radius      */
             0xea,               /* NOP       ;  (Y is set to 0)               */
-            0x86,  0xda         /* STY $DA   ;  set radiant timer             */
+            0x84,  0xda         /* STY $DA   ;  set radiant timer             */
     );
     vpatch(rom, 0x0ca68,    4,
             0xea,               /* NOP       ; Skip decrementing              */
@@ -1468,7 +1468,7 @@ static void permanent_torch(dw_rom *rom)
             0xea,               /* NOP       ;  fail when used                */
             0xea,               /* NOP       ;  outside of battle             */
             0xea                /* NOP                                        */
-    };
+    );
 }
 
 /**

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -1438,6 +1438,40 @@ static void threes_company(dw_rom *rom)
 }
 
 /**
+ * Makes all caves visible without using radiant or a torch.
+ *
+ * @param rom The rom struct
+ */
+static void permanent_torch(dw_rom *rom)
+{
+    if (!PERMANENT_TORCH(rom))
+        return;
+
+    printf("Illuminating all the caves...\n");
+
+    vpatch(rom, 0x02f18,    7,
+            0xa5,  0x03,        /* LDA #$03  ; When loading map               */
+            0x85,  0xd0,        /* STA $D0   ;  set size of torch radius      */
+            0xea,               /* NOP       ;  (Y is set to 0)               */
+            0x86,  0xda         /* STY $DA   ;  set radiant timer             */
+    );
+    vpatch(rom, 0x0ca68,    4,
+            0xea,               /* NOP       ; Skip decrementing              */
+            0xea,               /* NOP       ;  radiant timer                 */
+            0xea,               /* NOP       ;  when walking                  */
+            0xea                /* NOP                                        */
+    );
+    vpatch(rom, 0x0dd1e,    6,
+            0xea,               /* NOP       ; Skip map type check            */
+            0xea,               /* NOP       ;  when using torch              */
+            0xea,               /* NOP       ;  so it will always             */
+            0xea,               /* NOP       ;  fail when used                */
+            0xea,               /* NOP       ;  outside of battle             */
+            0xea                /* NOP                                        */
+    };
+}
+
+/**
  * Other various patches for gameplay, such as silver harp enemies, town and
  * dungeon map changes and moving some NPCs.
  *
@@ -1973,6 +2007,7 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     scared_metal_slimes(&rom);
     torch_in_battle(&rom);
     repel_mods(&rom);
+    permanent_torch(&rom);
     other_patches(&rom);
     credits(&rom);
 

--- a/common/dwr.h
+++ b/common/dwr.h
@@ -106,6 +106,7 @@
 #define NO_HURTMORE(x)        (x->flags & FLAG_u)
 #define RANDOM_PRICES(x)      (x->flags & FLAG_w)
 #define RANDOM_XP_REQS(x)     (x->flags & FLAG_x)
+#define PERMANENT_TORCH(x)    (x->flags & FLAG_y)
 #define SHUFFLE_CHESTS(x)     (x->flags & FLAG_C)
 #define DEATH_NECKLACE(x)     (x->flags & FLAG_D)
 #define FAST_XP(x)            (x->flags & FLAG_F)

--- a/ui/main-window.cpp
+++ b/ui/main-window.cpp
@@ -151,6 +151,7 @@ void MainWindow::layout()
     this->addOption('b', "Big Swamp",                 "M", "", FEATURES,  0, 1);
     this->addOption('r', "Repel in dungeons",                  FEATURES,  1, 1);
     this->addOption('p', "Permanent repel",                    FEATURES,  2, 1);
+    this->addOption('y', "Permanent torch",                    FEATURES,  3, 1);
 
     /* Monster flags */
     this->addOption('P', "Random Monster Abilities",           MONSTERS,  0, 0);


### PR DESCRIPTION
- Removes radiant from spells
- Removes the ability to use torches in caves (still usable as a weapon)
- When loading maps, sets the "torch radius" to the same size as the regular torch, with no "radiant timer" (the torch and radiant share code)

Closes #101 
