### PR TITLE
Checksum on the race start screen.

### DIFF
--- a/notes/free_space.txt
+++ b/notes/free_space.txt
@@ -39,6 +39,7 @@ C475  | C4BC |  71  | 3    | Torch/FW use in battle
 C4BC  | C4CE |  18  | 3    | Three's Company
 C4CE  | C4E8 |  26  | 3    | Cursed Princess
 C4E8  | C4F5 |  13  | 3    | Scared Metal Slimes
+C7EC  | C815 |  41  | 3    | Window data for new "Begin New Quest" window
 E158  | E16E |  22  | 3    | Scaled Metal Slime XP
 FF7D  | FF8E |  17  | 3    | Fighter's Ring fix
 FF54  | FF57 |   3  | 3    | Fighter's Ring fix


### PR DESCRIPTION
By request, this change places a quickly readable portion of the checksum on the race start screen. Helps with restreamers and VOD streams to make sure everyone is on the same page before things kick off.