### PR TITLE
Forfeit Trigger

### DIFF
--- a/notes/free_space.txt
+++ b/notes/free_space.txt
@@ -39,6 +39,7 @@ C475  | C4BC |  71  | 3    | Torch/FW use in battle
 C4BC  | C4CE |  18  | 3    | Three's Company
 C4CE  | C4E8 |  26  | 3    | Cursed Princess
 C4E8  | C4F5 |  13  | 3    | Scared Metal Slimes
+C900  | C927 |  40  | 3    | Forfeit Trigger
 E158  | E16E |  22  | 3    | Scaled Metal Slime XP
 FF7D  | FF8E |  17  | 3    | Fighter's Ring fix
 FF54  | FF57 |   3  | 3    | Fighter's Ring fix


### PR DESCRIPTION
Adds a forfeit trigger to the status screen. Let's players quit a seed, but still see their super cool end game stats.