### PR TITLE
Vendor shuffle

### DIFF
--- a/common/dwr.c
+++ b/common/dwr.c
@@ -641,7 +641,7 @@ static void shuffle_vendors(dw_rom *rom)
     mt_shuffle(vendor_dialog, sizeof(vendor_dialog), sizeof(uint8_t));
 
     for(i = 0; i<17; i++) {
-        if(NO_KEYS(rom) && vendor_dialog[i] == 0x4f || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c)
+        if(NO_KEYS(rom) && (vendor_dialog[i] == 0x4f || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c))
             vpatch(rom, vendor_address[i], 3, 0, 0, 0);
         else
             vpatch(rom, vendor_address[i]+2, 1, vendor_dialog[i]);

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -634,13 +634,13 @@ static void shuffle_vendors(dw_rom *rom)
     if (NO_KEYS(rom)) {
         // Put default key vendor data back, we'll remove them wherever they end up being after the shuffle
         vpatch(rom, 0x1783, 3, 0x78, 0x41, 0x0e); // Tantegel
-        vpatch(rom, 0x185c, 3, 0x62, 0x04, 0x0d); // Rimuldar
+        // vpatch(rom, 0x185c, 3, 0xa4, 0x07, 0x0d); // Rimuldar
         vpatch(rom, 0x181b, 3, 0xbb, 0x46, 0x0c); // Cantlin
     }
 
     mt_shuffle(vendor_dialog, sizeof(vendor_dialog), sizeof(uint8_t));
 
-    for(i = 0; i<17; i++) {
+    for(i = 0; i<sizeof(vendor_dialog) / sizeof(uint8_t); i++) {
         if(NO_KEYS(rom) && (vendor_dialog[i] == 0x0d || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c))
             vpatch(rom, vendor_address[i], 3, 0, 0, 0);
         else
@@ -2158,7 +2158,6 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     randomize_zone_layout(&rom);
     randomize_zones(&rom);
     randomize_shops(&rom);
-    shuffle_vendors(&rom);
     randomize_growth(&rom);
     randomize_spells(&rom);
     update_drops(&rom);
@@ -2172,6 +2171,7 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     open_charlock(&rom);
     chaos_mode(&rom);
     no_keys(&rom);
+    shuffle_vendors(&rom);
     cursed_princess(&rom);
     threes_company(&rom);
     scared_metal_slimes(&rom);

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -621,7 +621,7 @@ static void shuffle_vendors(dw_rom *rom)
         0x0a, // Cantlin item 1
         0x0b, // Cantlin item 2
         0x45, // Cantlin radishes
-        //0x4f, // Rimuldar keys
+        //0x0d, // Rimuldar keys
         0x0e, // Tantegel keys
         0x0c  // Cantlin keys
     };
@@ -634,14 +634,14 @@ static void shuffle_vendors(dw_rom *rom)
     if (NO_KEYS(rom)) {
         // Put default key vendor data back, we'll remove them wherever they end up being after the shuffle
         vpatch(rom, 0x1783, 3, 0x78, 0x41, 0x0e); // Tantegel
-        //vpatch(rom, 0x185c, 3, 0x62, 0x04, 0x4f); // Rimuldar
+        vpatch(rom, 0x185c, 3, 0x62, 0x04, 0x0d); // Rimuldar
         vpatch(rom, 0x181b, 3, 0xbb, 0x46, 0x0c); // Cantlin
     }
 
     mt_shuffle(vendor_dialog, sizeof(vendor_dialog), sizeof(uint8_t));
 
     for(i = 0; i<17; i++) {
-        if(NO_KEYS(rom) && (vendor_dialog[i] == 0x4f || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c))
+        if(NO_KEYS(rom) && (vendor_dialog[i] == 0x0d || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c))
             vpatch(rom, vendor_address[i], 3, 0, 0, 0);
         else
             vpatch(rom, vendor_address[i]+2, 1, vendor_dialog[i]);

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -575,6 +575,80 @@ static void randomize_shops(dw_rom *rom)
 }
 
 /**
+ * Shuffles the item, weapon/armor and key vendors (except Rimuldar key vendor)
+ *
+ * @param rom The rom struct
+ */
+static void shuffle_vendors(dw_rom *rom)
+{
+    int i;
+
+    // Rimuldar key vendor isn't included so we can have the same key logic
+    uint32_t vendor_address[17] = {
+        0x18ac, // Brecconary items
+        0x1894, // Brecconary weapons
+        0x1884, // Brecconary fairy water
+        0x18d8, // Kol weapons
+        0x18de, // Kol items
+        0x1907, // Garinham items
+        0x1910, // Garinham weapons
+        0x185f, // Rimuldar weapons
+        0x1805, // Cantlin weapon 1
+        0x1827, // Cantlin weapon 2
+        0x1833, // Cantlin weapon 3
+        0x182a, // Cantlin fairy water
+        0x181e, // Cantlin item 1
+        0x1824, // Cantlin item 2
+        0x1821, // Cantlin radishes
+        //0x185c, // Rimuldar keys
+        0x1783, // Tantegel keys
+        0x181b  // Cantlin keys
+    };
+
+    uint8_t vendor_dialog[17] = {
+        0x08, // Brecconary items
+        0x01, // Brecconary weapons
+        0x0f, // Brecconary fairy water
+        0x00, // Kol weapons
+        0x07, // Kol items
+        0x09, // Garinham items
+        0x02, // Garinham weapons
+        0x06, // Rimuldar weapons
+        0x03, // Cantlin weapon 1
+        0x05, // Cantlin weapon 2
+        0x04, // Cantlin weapon 3
+        0x10, // Cantlin fairy water
+        0x0a, // Cantlin item 1
+        0x0b, // Cantlin item 2
+        0x45, // Cantlin radishes
+        //0x4f, // Rimuldar keys
+        0x0e, // Tantegel keys
+        0x0c  // Cantlin keys
+    };
+
+    if (!SHUFFLE_VENDORS(rom))
+        return;
+
+    printf("Shuffling vendors across Alefgard...\n");
+
+    if (NO_KEYS(rom)) {
+        // Put default key vendor data back, we'll remove them wherever they end up being after the shuffle
+        vpatch(rom, 0x1783, 3, 0x78, 0x41, 0x0e); // Tantegel
+        //vpatch(rom, 0x185c, 3, 0x62, 0x04, 0x4f); // Rimuldar
+        vpatch(rom, 0x181b, 3, 0xbb, 0x46, 0x0c); // Cantlin
+    }
+
+    mt_shuffle(vendor_dialog, sizeof(vendor_dialog), sizeof(uint8_t));
+
+    for(i = 0; i<17; i++) {
+        if(NO_KEYS(rom) && vendor_dialog[i] == 0x4f || vendor_dialog[i] == 0x0e || vendor_dialog[i] == 0x0c)
+            vpatch(rom, vendor_address[i], 3, 0, 0, 0);
+        else
+            vpatch(rom, vendor_address[i]+2, 1, vendor_dialog[i]);
+    }
+}
+
+/**
  * Randomizes the player's stat growth
  *
  * @param rom The rom struct
@@ -2084,6 +2158,7 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     randomize_zone_layout(&rom);
     randomize_zones(&rom);
     randomize_shops(&rom);
+    shuffle_vendors(&rom);
     randomize_growth(&rom);
     randomize_spells(&rom);
     update_drops(&rom);

--- a/common/dwr.h
+++ b/common/dwr.h
@@ -28,6 +28,7 @@
 #define RANDOM_MAP(x)             (x->flags[ 0] & 0x03)
 #define RANDOMIZE_SPELLS(x)       (x->flags[ 1] & 0xc0)
 #define RANDOMIZE_SHOPS(x)        (x->flags[ 1] & 0x30)
+#define SHUFFLE_VENDORS(x)        (1 > 0)
 #define RANDOM_PRICES(x)          (x->flags[ 1] & 0x0c)
 #define RANDOM_XP_REQS(x)         (x->flags[ 1] & 0x03)
 #define HEAL_HURT_B4_MORE(x)      (x->flags[ 2] & 0xc0)


### PR DESCRIPTION
This was a request from someone (aaron2u2?) I saw in a twitch chat (NESCardinality or DWR?). This shuffles every weapon, tool, fairy water and key vendor (except for Rimuldar's key vendor), as well as the radish vendor. The locations, positions, sprites and prices are not modified. If "no keys" is on, then the Rimuldar key vendor and the two other key vendors, wherever they are, are removed as they would ordinarily be.

Of course, it would be possible to shuffle the Rimuldar key vendor as well, but I left him as is so the key logic does not have to change. Doing so would require significant changes I don't intend to do at the moment, especially without a proper conversation about it.

As with my flute music pull request, I opted not to change anything relating to the flags themselves for the moment.

[Edit] Cleaner implementation can be found [here](https://github.com/juef17/dwrandomizer) and a prebuilt web app is available [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/). Notably, this makes this flag compatible with the Disguised Dragonlord and Inn in Charlock flags, and the code is cleaner.