### PR TITLE
Inn in Charlock

### DIFF
--- a/common/dwr.c
+++ b/common/dwr.c
@@ -575,6 +575,34 @@ static void randomize_shops(dw_rom *rom)
 }
 
 /**
+ * Promotes Cantlin's bottom-left NPC to Charlock innkeeper
+ *
+ * @param rom The rom struct
+ */
+static void inn_in_charlock(dw_rom *rom)
+{
+    if (!INN_IN_CHARLOCK(rom))
+        return;
+
+    printf("Putting a bed & breakfast in Charlock...\n");
+
+    // Update the appropriate NPC tables locations
+    vpatch(rom, 0x1746, 1, 0x97ef + 3);
+    vpatch(rom, 0x175e, 1, 0x97f0 + 3);
+    vpatch(rom, 0x1748, 1, 0x97f4 + 3);
+    vpatch(rom, 0x1760, 1, 0x97f5 + 3);
+
+    // Update NPC data from Charlock basement to Cantlin.
+    // It would be more elegant to move rather than rewrite most of this,
+    // but I don't know of an easy way to do this.
+
+    // 011 for shopkeeper, 10101 for X, 011 for left-facing, 01000 for Y, 0x14 for inn dialogue
+    vpatch(rom, 0x17ee, 3, 0x75, 0x68, 0x14); // This is the guy.
+
+    vpatch(rom, 0x17ee + 3, 35, 0xff, 0xff, 0xa4, 0x24, 0x6c, 0xff, 0xff, 0xa4, 0x65, 0x6d, 0xff, 0x14, 0x4f, 0x4b, 0x45, 0x46, 0x60, 0x79, 0x51, 0x4c, 0xc4, 0x4e, 0x49, 0x76, 0x45, 0x03, 0xc9, 0x50, 0x4a, 0xae, 0x5c, 0x6b, 0x4f, 0x46, 0x48);
+}
+
+/**
  * Randomizes the player's stat growth
  *
  * @param rom The rom struct
@@ -2084,6 +2112,7 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     randomize_zone_layout(&rom);
     randomize_zones(&rom);
     randomize_shops(&rom);
+    inn_in_charlock(&rom);
     randomize_growth(&rom);
     randomize_spells(&rom);
     update_drops(&rom);

--- a/common/dwr.h
+++ b/common/dwr.h
@@ -70,6 +70,7 @@
 #define ROTATE_DUNGEONS(x)        (x->flags[10] & 0x0c)
 #define NO_ARMOR_IN_CHARLOCK(x)   (x->flags[10] & 0x30)
 #define EASY_CHARLOCK(x)          (x->flags[10] & 0xc0)
+#define INN_IN_CHARLOCK(x)        (1 > 0)
 
 #define CURSED_PRINCESS(x)        (x->flags[ 8] & 0x0c)
 #define THREES_COMPANY(x)         (x->flags[ 8] & 0x03)


### PR DESCRIPTION
This moves the bottom-left Cantlin NPC inside Charlock, near the treasury, and promotes him to an inkeeper. Should this be used in conjunction with the vendor shuffle patch, this one has to be done last as this changes the size and location of some NPC tables.

Why an inn in Charlock? Why not? Maybe this could be used with the easy Charlock flag, or maybe this would make a Charlock spike tile grind more viable.

Slight issue: the village music plays after spending the night at the inn, but it fixes itself as the music changes to something else (e.g. enemy encounter, cursed belt or death necklace use, outside, …).

[Edit] Cleaner implementation can be found [here](https://github.com/juef17/dwrandomizer) and a prebuilt web app is available [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/). Notably, this makes this flag compatible with the Disguised Dragonlord and Vendor Shuffle flags, and the code is cleaner.