### PR TITLE
Inn and key price shuffle

### DIFF
--- a/common/dwr.c
+++ b/common/dwr.c
@@ -1173,6 +1173,43 @@ static void summer_sale(dw_rom *rom)
 }
 
 /**
+ * Shuffles prices from all inns
+ *
+ * @param rom The rom struct
+ */
+static void shuffle_inn_prices(dw_rom *rom)
+{
+    uint8_t prices[5] = {6, 20, 25, 100, 55};
+    int i;
+
+    if (!SHUFFLE_INN_PRICES(rom))
+        return;
+
+    mt_shuffle(prices, sizeof(prices), sizeof(uint8_t));
+    for(i = 0; i < sizeof(prices) / sizeof(uint8_t); i++)
+        vpatch(rom, 0x198c + i, 1, prices[i]);
+}
+
+/**
+ * Shuffles prices from all key vendors (affects key resale value as well)
+ *
+ * @param rom The rom struct
+ */
+static void shuffle_key_prices(dw_rom *rom)
+{
+    uint8_t prices[3] = {53, 85, 98};
+    int i;
+
+    if (!SHUFFLE_KEY_PRICES(rom))
+        return;
+
+    mt_shuffle(prices, sizeof(prices), sizeof(uint8_t));
+    vpatch(rom, 0x196b, 1, prices[0]);
+    for(i = 0; i < sizeof(prices) / sizeof(uint8_t); i++)
+        vpatch(rom, 0x1989 + i, 1, prices[i]);
+}
+
+/**
  * Modifies the status window to show a death counter
  *
  * @param rom The rom struct
@@ -2089,6 +2126,8 @@ uint64_t dwr_randomize(const char* input_file, uint64_t seed, char *flags,
     update_drops(&rom);
     update_mp_reqs(&rom);
     lower_xp_reqs(&rom);
+    shuffle_inn_prices(&rom);
+    shuffle_key_prices(&rom);
     update_enemy_hp(&rom);
     dwr_fighters_ring(&rom);
     dwr_death_necklace(&rom);

--- a/common/dwr.c
+++ b/common/dwr.c
@@ -1204,7 +1204,7 @@ static void shuffle_key_prices(dw_rom *rom)
         return;
 
     mt_shuffle(prices, sizeof(prices), sizeof(uint8_t));
-    vpatch(rom, 0x196b, 1, prices[0]);
+    vpatch(rom, 0x196b, 1, prices[1]);
     for(i = 0; i < sizeof(prices) / sizeof(uint8_t); i++)
         vpatch(rom, 0x1989 + i, 1, prices[i]);
 }

--- a/common/dwr.h
+++ b/common/dwr.h
@@ -60,6 +60,8 @@
 #define SMALL_MAP(x)              (x->flags[13] & 0x40)
 #define VERY_SMALL_MAP(x)         (x->flags[13] & 0x80)
 #define RANDOM_MAP_SIZE(x)        (x->flags[13] & 0xc0)
+#define SHUFFLE_INN_PRICES(x)     (1 > 0)
+#define SHUFFLE_KEY_PRICES(x)     (1 > 0)
 
 #define NO_HURTMORE(x)            (x->flags[ 9] & 0xc0)
 #define NO_NUMBERS(x)             (x->flags[ 9] & 0x30)


### PR DESCRIPTION
This shuffles all 3 different key prices, and all 5 inn prices. The key resale value is correspondingly updated with half the price of Rimuldar's keys. This was a request from Kigalas in the DWR discord server.

[Edit] Flag is implemented in this web app: [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/), along with randomized prices. Source for that can be found [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/).