### PR TITLE
no_screen_flash updated to remove red flashes as well

### DIFF
--- a/common/dwr.c
+++ b/common/dwr.c
@@ -1936,13 +1936,20 @@ static void begin_quest_checksum(dw_rom *rom, uint64_t crc)
  */
 static void no_screen_flash(dw_rom *rom)
 {
+    int i;
+
     if (!NO_SCREEN_FLASH(rom))
         return;
 
     printf("Disabling screen flash for spells...\n");
+    
     /* Change the PPUMASK writes to disable flashing during spells */
     vpatch(rom, 0x0d38e,    1,  0x18);
     vpatch(rom, 0x0db40,    1,  0x18);
+
+    // NOP the whole red flash routine for deaths, swamp tiles and barrier tiles
+    for(i = 0; i<17; i++)
+        vpatch(rom, 0xee17 + i, 1, 0xea);
 }
 
 /**


### PR DESCRIPTION
It has been a request in the DWR discord server to have a way to remove the red flashes that happen upon death or walking onto swamp tiles and barrier tiles. This is done by changing all 17 bytes of the red-flashing code to all NOP bytes. Not very elegant, but it works very well. I'm not sure this is worth a flag in itself, given that those who dislike the spell flashing probably dislike the red flashes as well.

[Edit] Flag is implemented in this web app: [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/).