### PR TITLE
Among us — Make a random NPC the Dragonlord

### DIFF
--- a/common/dwr.h
+++ b/common/dwr.h
@@ -73,6 +73,7 @@
 
 #define CURSED_PRINCESS(x)        (x->flags[ 8] & 0x0c)
 #define THREES_COMPANY(x)         (x->flags[ 8] & 0x03)
+#define DISGUISED_DRAGONLORD(x)   (1 > 0)
 
 #define MODERN_SPELLS(x)          (x->flags[11] & 0xc0)
 #define NOIR_MODE(x)              (x->flags[11] & 0x30)


### PR DESCRIPTION
This was a request by EMP_AnyAmountOfMoney, made in chat in a DiabeetusThe2nd stream. The following is accomplished:

- A random NPC will have the Dragonlord dialogue;
- The NPC at the bottom of Charlock, still with the Dragonlord sprite, will tell the player the location and disguise of the new Dragonlord.
- Upon getting the Ball of Light, the player is teleported outside of the area the Dragonlord was fought in.

Notes:

- To achieve this, a merchant-type NPC in Tantegel is sacrificed to use his dialogue as the hint.
- I believe this to be 100% compatible with current flags (but not with a few of my previous pull requests, more on that later).
- Every NPC can be the Dragonlord, except for the King, the coordinates old man, the uncurse old man, and the Rimuldar key vendor. Additionnally, if the Open Charlock flag is off, it cannot be the Staff of rain old man, nor the Rainbow drop old man. Also, if the No Keys flag is on, it obviously cannot be a key vendor. This makes an approximate probability of 1/120 that a specific NPC is the Dragonlord.
- There are a few NPC specific checks: the princess (she won't come down and the king's dialogue will be different in the ending sequence), the vanilla Dragonlord (this is then indiscernible from a normal seed), and the sacrificed merchant (he's not sacrificed then: he can be the Dragonlord since his dialogue won't be used).
- There may be some graphical glitches in both the DL1 and DL2 fights, depending on the Dragonlord's location. None of these affect the ability to run or to complete the game.
- Depending on which NPC the Dragonlord is, it is likely that he's still gonna be there after defeating him, but the dialogue is still changed to a congratulatory one. This would of course be more polished, but would require more extensive hacking.

Now, this pull request has a large amount of code for the little it accomplishes. This is because most of the code is used to completely rebuild the NPC pointer tables and their content, which means it can now be very easy to change the number of NPCs in an area, as long as the total number of NPCs does not exceed the original one. I see at least two interesting uses for this:

1. Being able to completely remove an NPC. As an example, at the moment, when the No Keys flag is on, the Rimuldar key vendor is nulled, which creates an invisible bonkable tile in the top left corner of Rimuldar.
2. Make multiple NPC-manipulation flags compatible. For instance, my vendor shuffling pull request will not work with this at the moment, but it could if it used the code in this pull request.

In any case, this would of course require adjusments to this code, but I believe the bulk of the work has been done.

[Edit] Cleaner implementation can be found [here](https://github.com/juef17/dwrandomizer) and a prebuilt web app is available [here](http://snestop.jerther.com/misc/dwr/unofficial_juef/). Notably, this makes this flag compatible with the Vendor Shuffle and Inn in Charlock flags, and the code is much cleaner.